### PR TITLE
feat: поддержка упоминаний (mentions) при отправке сообщений

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ examples/**/.env
 
 # ralphex progress logs
 .ralphex/worktrees/
+
+docs/express-api/
+docs/rfc/
+docs/plans/

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,6 +64,10 @@ echo "Deploy OK" | express-botx send
 # С файлом-вложением
 express-botx send --file report.pdf "Отчёт за март"
 
+# С mentions (BotX wire-формат)
+express-botx send --mentions '[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Иван"}}]' \
+  "@{mention:aaa-bbb} Привет!"
+
 # Файл из stdin
 cat image.png | express-botx send --file - --file-name image.png
 
@@ -86,7 +90,12 @@ express-botx send --host express.company.ru --bot-id UUID --secret KEY --chat-id
 --force-dnd     доставить даже при DND
 --no-notify     не отправлять уведомление вообще
 --metadata      произвольный JSON для notification.metadata
+--mentions      JSON-массив mentions в wire-формате BotX API
 ```
+
+Поле `--mentions` принимает JSON-массив в формате BotX API. Текст сообщения должен уже содержать
+соответствующие placeholder'ы (`@{mention:...}`, `@@{mention:...}`, `##{mention:...}`).
+Если JSON невалиден или не является массивом, команда завершится с ошибкой.
 
 ---
 
@@ -180,6 +189,10 @@ echo "OK" | express-botx enqueue --bot-id UUID --chat-id UUID
 
 # С файлом-вложением
 express-botx enqueue --file report.pdf --bot-id UUID --chat-id UUID "Отчёт"
+
+# С mentions (BotX wire-формат)
+express-botx enqueue --mentions '[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Иван"}}]' \
+  --bot-id UUID --chat-id UUID "@{mention:aaa-bbb} Привет!"
 ```
 
 При успехе выводит `request_id` (text) или `{"ok":true,"queued":true,"request_id":"..."}` (json).
@@ -200,7 +213,12 @@ express-botx enqueue --file report.pdf --bot-id UUID --chat-id UUID "Отчёт"
 --force-dnd      доставить при DND
 --no-notify      без уведомления
 --metadata       JSON для notification.metadata
+--mentions       JSON-массив mentions в wire-формате BotX API
 ```
+
+Поле `--mentions` принимает JSON-массив в формате BotX API. Текст сообщения должен уже содержать
+соответствующие placeholder'ы (`@{mention:...}`, `@@{mention:...}`, `##{mention:...}`).
+Если JSON невалиден или не является массивом, команда завершится с ошибкой.
 
 ### Режимы маршрутизации (routing modes)
 
@@ -254,6 +272,37 @@ HTTP payload расширяется полями `routing_mode` и `bot_id` дл
 ```json
 {"routing_mode": "direct", "bot_id": "bot-uuid", "chat_id": "chat-uuid", "message": "deploy ok"}
 ```
+
+### Поля HTTP payload
+
+Эндпоинт `/send` принимает `application/json` и `multipart/form-data`. Основные поля:
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `chat_id` | string | UUID или алиас чата (обязательно) |
+| `message` | string | Текст сообщения |
+| `file` | object | Вложение: `{"name": "...", "data": "base64..."}` |
+| `status` | string | `ok` или `error` (по умолчанию: `ok`) |
+| `metadata` | JSON | Произвольный JSON для `notification.metadata` |
+| `mentions` | JSON array | Массив mentions в wire-формате BotX API |
+| `opts` | object | Опции доставки: `silent`, `stealth`, `force_dnd`, `no_notify` |
+
+Пример с mentions через HTTP API:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/send \
+    -H "Authorization: Bearer <api-key>" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "chat_id": "CHAT-UUID",
+      "message": "@{mention:aaa-bbb} Deploy completed",
+      "mentions": [{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Иван"}}]
+    }'
+```
+
+Поле `mentions` принимает JSON-массив в формате BotX API. Текст сообщения должен уже содержать
+соответствующие placeholder'ы (`@{mention:...}`, `@@{mention:...}`, `##{mention:...}`).
+При multipart-запросе `mentions` передаётся как строковое JSON-поле формы.
 
 ---
 

--- a/internal/botapi/client.go
+++ b/internal/botapi/client.go
@@ -74,7 +74,7 @@ func (c *Client) ListChats(ctx context.Context) ([]ChatInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing chats: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
 	elapsed := time.Since(start)
 
 	if resp.StatusCode != http.StatusOK {
@@ -154,7 +154,7 @@ func (c *Client) getUser(ctx context.Context, path string) (*UserInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting user: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
 	elapsed := time.Since(start)
 
 	if resp.StatusCode != http.StatusOK {
@@ -185,6 +185,7 @@ type SendNotification struct {
 	Status   string               `json:"status"`
 	Body     string               `json:"body"`
 	Metadata json.RawMessage      `json:"metadata,omitempty"`
+	Mentions json.RawMessage      `json:"mentions,omitempty"`
 	Opts     *NotificationMsgOpts `json:"opts,omitempty"`
 }
 
@@ -220,6 +221,7 @@ type SendParams struct {
 	Status   string // "ok" or "error"
 	File     *SendFile
 	Metadata json.RawMessage
+	Mentions json.RawMessage
 	Silent   bool
 	Stealth  bool
 	ForceDND bool
@@ -237,6 +239,7 @@ func BuildSendRequest(p *SendParams) *SendRequest {
 			Status:   p.Status,
 			Body:     p.Message,
 			Metadata: p.Metadata,
+			Mentions: p.Mentions,
 		}
 		if p.Silent {
 			sr.Notification.Opts = &NotificationMsgOpts{
@@ -262,11 +265,17 @@ func BuildSendRequest(p *SendParams) *SendRequest {
 		}
 	}
 
-	// File-only with metadata: still need a notification for metadata
-	if sr.Notification == nil && len(p.Metadata) > 0 {
+	// File-only with metadata/mentions: still need a notification to carry them
+	if sr.Notification == nil && (len(p.Metadata) > 0 || len(p.Mentions) > 0) {
 		sr.Notification = &SendNotification{
 			Status:   p.Status,
 			Metadata: p.Metadata,
+			Mentions: p.Mentions,
+		}
+		if p.Silent {
+			sr.Notification.Opts = &NotificationMsgOpts{
+				SilentResponse: true,
+			}
 		}
 	}
 
@@ -313,7 +322,7 @@ func (c *Client) SendWithSyncID(ctx context.Context, sr *SendRequest) (string, e
 	if err != nil {
 		return "", fmt.Errorf("sending: %w", err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
 	elapsed := time.Since(start)
 
 	if resp.StatusCode == http.StatusUnauthorized {

--- a/internal/botapi/send_test.go
+++ b/internal/botapi/send_test.go
@@ -132,3 +132,182 @@ func TestBuildSendRequest_NoOpts(t *testing.T) {
 		t.Error("expected nil Notification.Opts when silent=false")
 	}
 }
+
+func TestBuildSendRequest_Mentions(t *testing.T) {
+	mentions := json.RawMessage(`[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Ivan"}}]`)
+	sr := BuildSendRequest(&SendParams{
+		ChatID:   "chat-1",
+		Message:  "@{mention:aaa-bbb} hello",
+		Status:   "ok",
+		Mentions: mentions,
+	})
+	if sr.Notification == nil {
+		t.Fatal("expected Notification")
+	}
+	if string(sr.Notification.Mentions) != string(mentions) {
+		t.Errorf("Mentions = %s, want %s", sr.Notification.Mentions, mentions)
+	}
+}
+
+func TestBuildSendRequest_FileMetadataMentions(t *testing.T) {
+	meta := json.RawMessage(`{"key":"val"}`)
+	mentions := json.RawMessage(`[{"mention_id":"aaa","mention_type":"all","mention_data":null}]`)
+	sr := BuildSendRequest(&SendParams{
+		ChatID:   "chat-1",
+		Status:   "ok",
+		File:     &SendFile{FileName: "f.txt", Data: "data:;base64,"},
+		Metadata: meta,
+		Mentions: mentions,
+	})
+	if sr.Notification == nil {
+		t.Fatal("expected Notification for file + metadata + mentions")
+	}
+	if sr.Notification.Body != "" {
+		t.Errorf("Body = %q, want empty", sr.Notification.Body)
+	}
+	if string(sr.Notification.Metadata) != string(meta) {
+		t.Errorf("Metadata = %s, want %s", sr.Notification.Metadata, meta)
+	}
+	if string(sr.Notification.Mentions) != string(mentions) {
+		t.Errorf("Mentions = %s, want %s", sr.Notification.Mentions, mentions)
+	}
+}
+
+func TestBuildSendRequest_MentionsInJSON(t *testing.T) {
+	mentions := json.RawMessage(`[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Ivan"}}]`)
+	sr := BuildSendRequest(&SendParams{
+		ChatID:   "chat-1",
+		Message:  "@{mention:aaa-bbb} hello",
+		Status:   "ok",
+		Mentions: mentions,
+	})
+
+	data, err := json.Marshal(sr)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	var notif map[string]json.RawMessage
+	if err := json.Unmarshal(raw["notification"], &notif); err != nil {
+		t.Fatalf("json.Unmarshal notification: %v", err)
+	}
+
+	if _, ok := notif["mentions"]; !ok {
+		t.Fatal("expected mentions key in serialized notification JSON")
+	}
+
+	// Verify the mentions value round-trips correctly
+	var got []map[string]interface{}
+	if err := json.Unmarshal(notif["mentions"], &got); err != nil {
+		t.Fatalf("json.Unmarshal mentions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(got))
+	}
+	if got[0]["mention_id"] != "aaa-bbb" {
+		t.Errorf("mention_id = %v, want aaa-bbb", got[0]["mention_id"])
+	}
+	if got[0]["mention_type"] != "user" {
+		t.Errorf("mention_type = %v, want user", got[0]["mention_type"])
+	}
+}
+
+func TestBuildSendRequest_EmptyMentionsArray(t *testing.T) {
+	// Semantic decision: empty array [] is passed through as-is (not omitted).
+	// json.RawMessage(`[]`) has len > 0, so omitempty does not drop it.
+	// This allows callers to explicitly send an empty mentions array if needed.
+	sr := BuildSendRequest(&SendParams{
+		ChatID:   "chat-1",
+		Message:  "hello",
+		Status:   "ok",
+		Mentions: json.RawMessage(`[]`),
+	})
+
+	if sr.Notification == nil {
+		t.Fatal("expected Notification")
+	}
+	if string(sr.Notification.Mentions) != "[]" {
+		t.Errorf("Mentions = %s, want []", sr.Notification.Mentions)
+	}
+
+	// Verify it appears in the serialized JSON
+	data, err := json.Marshal(sr)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	var notif map[string]json.RawMessage
+	if err := json.Unmarshal(raw["notification"], &notif); err != nil {
+		t.Fatalf("json.Unmarshal notification: %v", err)
+	}
+
+	if _, ok := notif["mentions"]; !ok {
+		t.Fatal("expected mentions key in JSON even for empty array")
+	}
+	if string(notif["mentions"]) != "[]" {
+		t.Errorf("serialized mentions = %s, want []", notif["mentions"])
+	}
+}
+
+func TestBuildSendRequest_FileMetadataMentionsSilent(t *testing.T) {
+	meta := json.RawMessage(`{"key":"val"}`)
+	mentions := json.RawMessage(`[{"mention_id":"aaa","mention_type":"all","mention_data":null}]`)
+	sr := BuildSendRequest(&SendParams{
+		ChatID:   "chat-1",
+		Status:   "ok",
+		File:     &SendFile{FileName: "f.txt", Data: "data:;base64,"},
+		Metadata: meta,
+		Mentions: mentions,
+		Silent:   true,
+	})
+	if sr.Notification == nil {
+		t.Fatal("expected Notification for file + metadata + mentions + silent")
+	}
+	if sr.Notification.Opts == nil || !sr.Notification.Opts.SilentResponse {
+		t.Error("expected SilentResponse=true in fallback notification")
+	}
+	if string(sr.Notification.Metadata) != string(meta) {
+		t.Errorf("Metadata = %s, want %s", sr.Notification.Metadata, meta)
+	}
+	if string(sr.Notification.Mentions) != string(mentions) {
+		t.Errorf("Mentions = %s, want %s", sr.Notification.Mentions, mentions)
+	}
+}
+
+func TestBuildSendRequest_NilMentionsOmitted(t *testing.T) {
+	// When mentions is nil, it should be omitted from the serialized JSON.
+	sr := BuildSendRequest(&SendParams{
+		ChatID:  "chat-1",
+		Message: "hello",
+		Status:  "ok",
+	})
+
+	data, err := json.Marshal(sr)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	var notif map[string]json.RawMessage
+	if err := json.Unmarshal(raw["notification"], &notif); err != nil {
+		t.Fatalf("json.Unmarshal notification: %v", err)
+	}
+
+	if _, ok := notif["mentions"]; ok {
+		t.Errorf("expected mentions to be omitted from JSON when nil, got %s", notif["mentions"])
+	}
+}

--- a/internal/cmd/enqueue.go
+++ b/internal/cmd/enqueue.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -33,6 +34,7 @@ func runEnqueue(args []string, deps Deps) error {
 	var forceDND bool
 	var noNotify bool
 	var metadata string
+	var mentions string
 
 	globalFlags(fs, &flags)
 	fs.StringVar(&flags.ChatID, "chat-id", "", "target chat UUID or alias")
@@ -46,6 +48,7 @@ func runEnqueue(args []string, deps Deps) error {
 	fs.BoolVar(&forceDND, "force-dnd", false, "deliver even if recipient has DND")
 	fs.BoolVar(&noNotify, "no-notify", false, "do not send notification at all")
 	fs.StringVar(&metadata, "metadata", "", "arbitrary JSON for notification.metadata")
+	fs.StringVar(&mentions, "mentions", "", "JSON array of mentions in BotX API wire format")
 	fs.Usage = func() {
 		fmt.Fprintf(deps.Stderr, `Usage: express-botx enqueue [options] [message]
 
@@ -231,6 +234,20 @@ Options:
 		meta = raw
 	}
 
+	// Validate mentions
+	var ment json.RawMessage
+	if mentions != "" {
+		raw := json.RawMessage(mentions)
+		if !json.Valid(raw) {
+			return fmt.Errorf("--mentions is not valid JSON")
+		}
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return fmt.Errorf("--mentions must be a JSON array, got %s", string(trimmed[:1]))
+		}
+		ment = raw
+	}
+
 	// Create publisher
 	pub, err := queue.NewPublisher(cfg.Queue.Driver, cfg.Queue.URL, cfg.Queue.Name)
 	if err != nil {
@@ -255,6 +272,7 @@ Options:
 			Message:  message,
 			Status:   status,
 			Metadata: meta,
+			Mentions: ment,
 			Opts: queue.DeliveryOpts{
 				Silent:   silent,
 				Stealth:  stealth,

--- a/internal/cmd/enqueue_test.go
+++ b/internal/cmd/enqueue_test.go
@@ -746,6 +746,106 @@ catalog:
 	}
 }
 
+func TestEnqueue_WithMentions(t *testing.T) {
+	testFakeQueue.Reset()
+
+	cfgPath := writeTestConfig(t, `
+queue:
+  driver: testfake
+  url: fake://localhost
+  name: test-work
+`)
+	deps, stdout, _ := testDeps()
+	deps.IsTerminal = true
+
+	mentions := `[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Ivan"}}]`
+	err := runEnqueue([]string{
+		"--config", cfgPath,
+		"--bot-id", "00000000-0000-0000-0000-000000000b01",
+		"--chat-id", "00000000-0000-0000-0000-000000000c01",
+		"--routing-mode", "direct",
+		"--mentions", mentions,
+		"@{mention:aaa-bbb} hello",
+	}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	if len(out) != 36 {
+		t.Errorf("expected UUID request_id, got %q", out)
+	}
+
+	msgs := testFakeQueue.WorkMessages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 work message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+	if msg.Payload.Message != "@{mention:aaa-bbb} hello" {
+		t.Errorf("Message = %q, want %q", msg.Payload.Message, "@{mention:aaa-bbb} hello")
+	}
+	if string(msg.Payload.Mentions) != mentions {
+		t.Errorf("Mentions = %s, want %s", string(msg.Payload.Mentions), mentions)
+	}
+}
+
+func TestEnqueue_MentionsInvalidJSON(t *testing.T) {
+	testFakeQueue.Reset()
+
+	cfgPath := writeTestConfig(t, `
+queue:
+  driver: testfake
+  url: fake://localhost
+  name: test-work
+`)
+	deps, _, _ := testDeps()
+	deps.IsTerminal = true
+
+	err := runEnqueue([]string{
+		"--config", cfgPath,
+		"--bot-id", "00000000-0000-0000-0000-000000000b01",
+		"--chat-id", "00000000-0000-0000-0000-000000000c01",
+		"--routing-mode", "direct",
+		"--mentions", `{not valid json`,
+		"hello",
+	}, deps)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "--mentions is not valid JSON") {
+		t.Errorf("expected '--mentions is not valid JSON' error, got: %v", err)
+	}
+}
+
+func TestEnqueue_MentionsNotArray(t *testing.T) {
+	testFakeQueue.Reset()
+
+	cfgPath := writeTestConfig(t, `
+queue:
+  driver: testfake
+  url: fake://localhost
+  name: test-work
+`)
+	deps, _, _ := testDeps()
+	deps.IsTerminal = true
+
+	err := runEnqueue([]string{
+		"--config", cfgPath,
+		"--bot-id", "00000000-0000-0000-0000-000000000b01",
+		"--chat-id", "00000000-0000-0000-0000-000000000c01",
+		"--routing-mode", "direct",
+		"--mentions", `{"mention_id":"aaa"}`,
+		"hello",
+	}, deps)
+	if err == nil {
+		t.Fatal("expected error for non-array JSON")
+	}
+	if !strings.Contains(err.Error(), "--mentions must be a JSON array") {
+		t.Errorf("expected '--mentions must be a JSON array' error, got: %v", err)
+	}
+}
+
 func TestEnqueue_NoMessage_Error(t *testing.T) {
 	cfgPath := writeTestConfig(t, `
 queue:

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -28,6 +29,7 @@ func runSend(args []string, deps Deps) error {
 	var forceDND bool
 	var noNotify bool
 	var metadata string
+	var mentions string
 
 	globalFlags(fs, &flags)
 	fs.StringVar(&flags.ChatID, "chat-id", "", "target chat UUID or alias")
@@ -40,6 +42,7 @@ func runSend(args []string, deps Deps) error {
 	fs.BoolVar(&forceDND, "force-dnd", false, "deliver even if recipient has DND")
 	fs.BoolVar(&noNotify, "no-notify", false, "do not send notification at all")
 	fs.StringVar(&metadata, "metadata", "", "arbitrary JSON for notification.metadata")
+	fs.StringVar(&mentions, "mentions", "", "JSON array of mentions in BotX API wire format")
 	fs.Usage = func() {
 		fmt.Fprintf(deps.Stderr, `Usage: express-botx send [options] [message]
 
@@ -152,6 +155,21 @@ Options:
 		meta = raw
 	}
 
+	// Validate mentions
+	var ment json.RawMessage
+	if mentions != "" {
+		raw := json.RawMessage(mentions)
+		if !json.Valid(raw) {
+			return fmt.Errorf("--mentions is not valid JSON")
+		}
+		// Must be a JSON array
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return fmt.Errorf("--mentions must be a JSON array, got %s", string(trimmed[:1]))
+		}
+		ment = raw
+	}
+
 	// Build SendRequest
 	sr := botapi.BuildSendRequest(&botapi.SendParams{
 		ChatID:   cfg.ChatID,
@@ -159,6 +177,7 @@ Options:
 		Status:   status,
 		File:     fileAttachment,
 		Metadata: meta,
+		Mentions: ment,
 		Silent:   silent,
 		Stealth:  stealth,
 		ForceDND: forceDND,

--- a/internal/cmd/send_test.go
+++ b/internal/cmd/send_test.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockBotxSend captures requests sent to /api/v4/botx/notifications/direct.
+type mockBotxSend struct {
+	mu    sync.Mutex
+	calls []json.RawMessage
+	srv   *httptest.Server
+}
+
+func newMockBotxSend() *mockBotxSend {
+	m := &mockBotxSend{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /api/v4/botx/notifications/direct", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		m.mu.Lock()
+		m.calls = append(m.calls, json.RawMessage(body))
+		m.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprintf(w, `{"status":"ok","result":{"sync_id":"sync-1"}}`)
+	})
+
+	m.srv = httptest.NewServer(mux)
+	return m
+}
+
+func (m *mockBotxSend) close() { m.srv.Close() }
+
+func (m *mockBotxSend) lastCall() json.RawMessage {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+	return m.calls[len(m.calls)-1]
+}
+
+func TestSend_WithMentions(t *testing.T) {
+	mock := newMockBotxSend()
+	defer mock.close()
+
+	cfgPath := writeTestConfig(t, fmt.Sprintf(`
+bots:
+  default:
+    host: %s
+    id: 00000000-0000-0000-0000-000000000001
+    token: test-token
+`, mock.srv.URL))
+
+	deps, _, _ := testDeps()
+	deps.IsTerminal = true
+
+	mentions := `[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Ivan"}}]`
+	err := runSend([]string{
+		"--config", cfgPath,
+		"--chat-id", "00000000-0000-0000-0000-00000000c001",
+		"--mentions", mentions,
+		"@{mention:aaa-bbb} hello",
+	}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw := mock.lastCall()
+	if raw == nil {
+		t.Fatal("expected a captured request, got none")
+	}
+
+	var req struct {
+		GroupChatID  string `json:"group_chat_id"`
+		Notification *struct {
+			Body     string          `json:"body"`
+			Mentions json.RawMessage `json:"mentions"`
+		} `json:"notification"`
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal captured request: %v", err)
+	}
+
+	if req.GroupChatID != "00000000-0000-0000-0000-00000000c001" {
+		t.Errorf("GroupChatID = %q, want %q", req.GroupChatID, "00000000-0000-0000-0000-00000000c001")
+	}
+	if req.Notification == nil {
+		t.Fatal("expected notification, got nil")
+	}
+	if req.Notification.Body != "@{mention:aaa-bbb} hello" {
+		t.Errorf("Body = %q, want %q", req.Notification.Body, "@{mention:aaa-bbb} hello")
+	}
+
+	// Verify mentions passed through unchanged
+	if string(req.Notification.Mentions) != mentions {
+		t.Errorf("Mentions = %s, want %s", string(req.Notification.Mentions), mentions)
+	}
+}
+
+func TestSend_MentionsInvalidJSON(t *testing.T) {
+	deps, _, _ := testDeps()
+	deps.IsTerminal = true
+
+	cfgPath := writeTestConfig(t, `
+bots:
+  default:
+    host: https://example.com
+    id: 00000000-0000-0000-0000-000000000001
+    token: test-token
+`)
+
+	err := runSend([]string{
+		"--config", cfgPath,
+		"--chat-id", "00000000-0000-0000-0000-00000000c001",
+		"--mentions", `{not valid json`,
+		"hello",
+	}, deps)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "--mentions is not valid JSON") {
+		t.Errorf("expected '--mentions is not valid JSON' error, got: %v", err)
+	}
+}
+
+func TestSend_MentionsNotArray(t *testing.T) {
+	deps, _, _ := testDeps()
+	deps.IsTerminal = true
+
+	cfgPath := writeTestConfig(t, `
+bots:
+  default:
+    host: https://example.com
+    id: 00000000-0000-0000-0000-000000000001
+    token: test-token
+`)
+
+	err := runSend([]string{
+		"--config", cfgPath,
+		"--chat-id", "00000000-0000-0000-0000-00000000c001",
+		"--mentions", `{"mention_id":"aaa"}`,
+		"hello",
+	}, deps)
+	if err == nil {
+		t.Fatal("expected error for non-array JSON")
+	}
+	if !strings.Contains(err.Error(), "--mentions must be a JSON array") {
+		t.Errorf("expected '--mentions must be a JSON array' error, got: %v", err)
+	}
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -345,6 +345,7 @@ func buildSendRequest(p *server.SendPayload) *botapi.SendRequest {
 		Message:  p.Message,
 		Status:   p.Status,
 		Metadata: p.Metadata,
+		Mentions: p.Mentions,
 	}
 	if p.File != nil {
 		params.File = botapi.BuildFileAttachmentFromBase64(p.File.Name, p.File.Data)
@@ -814,8 +815,10 @@ func runServeEnqueue(flags config.Flags, listenFlag, apiKeyFlag string, deps Dep
 				CatalogRevision: routeCatalogRevision,
 			},
 			Payload: queue.Payload{
-				Message: p.Message,
-				Status:  p.Status,
+				Message:  p.Message,
+				Status:   p.Status,
+				Metadata: p.Metadata,
+				Mentions: p.Mentions,
 			},
 			ReplyTo:    cfg.Queue.ReplyQueue,
 			EnqueuedAt: time.Now().UTC(),
@@ -828,10 +831,6 @@ func runServeEnqueue(flags config.Flags, listenFlag, apiKeyFlag string, deps Dep
 				ForceDND: p.Opts.ForceDND,
 				NoNotify: p.Opts.NoNotify,
 			}
-		}
-
-		if p.Metadata != nil {
-			msg.Payload.Metadata = p.Metadata
 		}
 
 		if p.File != nil {

--- a/internal/cmd/serve_integration_test.go
+++ b/internal/cmd/serve_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lavr/express-botx/internal/botapi"
 	"github.com/lavr/express-botx/internal/config"
+	"github.com/lavr/express-botx/internal/queue"
 	"github.com/lavr/express-botx/internal/server"
 )
 
@@ -32,6 +33,7 @@ type capturedSend struct {
 		Status   string          `json:"status"`
 		Body     string          `json:"body"`
 		Metadata json.RawMessage `json:"metadata,omitempty"`
+		Mentions json.RawMessage `json:"mentions,omitempty"`
 	} `json:"notification,omitempty"`
 	File *struct {
 		FileName string `json:"file_name"`
@@ -821,6 +823,61 @@ func TestBotSender_NilCache(t *testing.T) {
 	}
 	if calls[0].Notification == nil || calls[0].Notification.Body != "nil cache test" {
 		t.Errorf("unexpected notification: %+v", calls[0].Notification)
+	}
+}
+
+// TestBuildSendRequest_SyncPathMentions verifies that mentions from
+// server.SendPayload are preserved in the BotX SendRequest (sync path).
+func TestBuildSendRequest_SyncPathMentions(t *testing.T) {
+	mentions := json.RawMessage(`[{"mention_id":"aaa","mention_type":"user","mention_data":{"user_huid":"xxx"}}]`)
+	payload := &server.SendPayload{
+		ChatID:   "chat-001",
+		Message:  "@{mention:aaa} hello",
+		Mentions: mentions,
+	}
+
+	sr := buildSendRequest(payload)
+
+	if sr.Notification == nil {
+		t.Fatal("expected notification to be set")
+	}
+	if string(sr.Notification.Mentions) != string(mentions) {
+		t.Errorf("Mentions = %s, want %s", sr.Notification.Mentions, mentions)
+	}
+	if sr.Notification.Body != "@{mention:aaa} hello" {
+		t.Errorf("Body = %q, want %q", sr.Notification.Body, "@{mention:aaa} hello")
+	}
+}
+
+// TestBuildSendRequest_AsyncPathMentions verifies that mentions survive
+// the full async pipeline: SendPayload -> queue.WorkMessage -> buildSendRequestFromWork.
+func TestBuildSendRequest_AsyncPathMentions(t *testing.T) {
+	mentions := json.RawMessage(`[{"mention_id":"bbb","mention_type":"contact","mention_data":{"user_huid":"yyy"}}]`)
+
+	// Simulate what runServeEnqueue does: build WorkMessage from SendPayload
+	msg := &queue.WorkMessage{
+		RequestID: "req-async-mentions",
+		Routing: queue.Routing{
+			BotID:  "bot-001",
+			ChatID: "chat-001",
+		},
+		Payload: queue.Payload{
+			Message:  "@{mention:bbb} привет",
+			Status:   "ok",
+			Mentions: mentions,
+		},
+	}
+
+	sr := buildSendRequestFromWork(msg)
+
+	if sr.Notification == nil {
+		t.Fatal("expected notification to be set")
+	}
+	if string(sr.Notification.Mentions) != string(mentions) {
+		t.Errorf("Mentions = %s, want %s", sr.Notification.Mentions, mentions)
+	}
+	if sr.Notification.Body != "@{mention:bbb} привет" {
+		t.Errorf("Body = %q, want %q", sr.Notification.Body, "@{mention:bbb} привет")
 	}
 }
 

--- a/internal/cmd/worker.go
+++ b/internal/cmd/worker.go
@@ -388,6 +388,7 @@ func buildSendRequestFromWork(msg *queue.WorkMessage) *botapi.SendRequest {
 		Message:  msg.Payload.Message,
 		Status:   msg.Payload.Status,
 		Metadata: msg.Payload.Metadata,
+		Mentions: msg.Payload.Mentions,
 		Silent:   msg.Payload.Opts.Silent,
 		Stealth:  msg.Payload.Opts.Stealth,
 		ForceDND: msg.Payload.Opts.ForceDND,

--- a/internal/cmd/worker_test.go
+++ b/internal/cmd/worker_test.go
@@ -656,6 +656,87 @@ func TestWorker_HandleMessage_WithFileAttachment(t *testing.T) {
 	}
 }
 
+func TestWorker_HandleMessage_WithMentions(t *testing.T) {
+	mock := newMockBotxAPI()
+	botxSrv := httptest.NewServer(mock.handler())
+	defer botxSrv.Close()
+
+	fakeQ := queue.NewFake()
+
+	cfg := &config.Config{
+		Bots: map[string]config.BotConfig{
+			"alerts": {
+				Host:   botxSrv.URL,
+				ID:     "bot-uuid-mentions",
+				Secret: "test-secret",
+			},
+		},
+		Cache: config.CacheConfig{Type: "none"},
+	}
+
+	w, err := newWorkerRunner(cfg, fakeQ, apm.New(), false)
+	if err != nil {
+		t.Fatalf("newWorkerRunner: %v", err)
+	}
+
+	mentions := json.RawMessage(`[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx","name":"Иван"}}]`)
+
+	msg := &queue.WorkMessage{
+		RequestID: "req-mentions",
+		Routing: queue.Routing{
+			BotID:  "bot-uuid-mentions",
+			ChatID: "chat-uuid-001",
+		},
+		Payload: queue.Payload{
+			Message:  "@{mention:aaa-bbb} Привет!",
+			Status:   "ok",
+			Mentions: mentions,
+		},
+		ReplyTo:    "test-replies",
+		EnqueuedAt: time.Now().UTC(),
+	}
+
+	err = w.handleMessage(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify BotX API was called with mentions
+	calls := mock.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 BotX API call, got %d", len(calls))
+	}
+	if calls[0].Notification == nil {
+		t.Fatal("expected notification to be set")
+	}
+	if calls[0].Notification.Body != "@{mention:aaa-bbb} Привет!" {
+		t.Errorf("Body = %q, want %q", calls[0].Notification.Body, "@{mention:aaa-bbb} Привет!")
+	}
+	if calls[0].Notification.Mentions == nil {
+		t.Fatal("expected mentions in BotX API request")
+	}
+
+	var gotMentions []map[string]interface{}
+	if err := json.Unmarshal(calls[0].Notification.Mentions, &gotMentions); err != nil {
+		t.Fatalf("failed to unmarshal mentions: %v", err)
+	}
+	if len(gotMentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(gotMentions))
+	}
+	if gotMentions[0]["mention_id"] != "aaa-bbb" {
+		t.Errorf("mention_id = %v, want %q", gotMentions[0]["mention_id"], "aaa-bbb")
+	}
+
+	// Verify result was published
+	results := fakeQ.Results("test-replies")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != "sent" {
+		t.Errorf("Status = %q, want %q", results[0].Status, "sent")
+	}
+}
+
 func TestWorker_HandleMessage_DryRun(t *testing.T) {
 	mock := newMockBotxAPI()
 	botxSrv := httptest.NewServer(mock.handler())

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -35,6 +35,7 @@ type Payload struct {
 	File     *FileAttachment `json:"file,omitempty"`
 	Opts     DeliveryOpts    `json:"opts"`
 	Metadata json.RawMessage `json:"metadata,omitempty"`
+	Mentions json.RawMessage `json:"mentions,omitempty"`
 }
 
 // FileAttachment is a base64-encoded file for async delivery.

--- a/internal/server/api/openapi.yaml
+++ b/internal/server/api/openapi.yaml
@@ -141,6 +141,17 @@ paths:
                   chat_id: ops-alerts
                   message: "Build #42 failed"
                   status: error
+              mentions:
+                summary: Message with mentions
+                value:
+                  chat_id: "1a2b3c4d-5e6f-7890-abcd-ef1234567890"
+                  message: "@{mention:aaa-bbb} Deploy completed"
+                  mentions:
+                    - mention_id: aaa-bbb
+                      mention_type: user
+                      mention_data:
+                        user_huid: "f16cdc5f-6366-5552-9ecd-c36290ab3d11"
+                        name: "Иван"
               file:
                 summary: Message with file
                 value:
@@ -172,6 +183,9 @@ paths:
                 metadata:
                   type: string
                   description: Arbitrary JSON string
+                mentions:
+                  type: string
+                  description: JSON string containing an array of mentions in BotX API wire format
       responses:
         "200":
           description: Message sent
@@ -555,6 +569,24 @@ components:
         metadata:
           type: object
           description: Arbitrary JSON passed to notification.metadata
+        mentions:
+          type: array
+          description: |
+            Array of mentions in BotX API wire format. The message text must already contain
+            the correct placeholders (@{mention:...}, @@{mention:...}, ##{mention:...}).
+            Passed through to BotX API without modification.
+          items:
+            type: object
+            properties:
+              mention_id:
+                type: string
+                description: Unique mention identifier referenced in message placeholders
+              mention_type:
+                type: string
+                description: "Type of mention: user, contact, chat, channel, all"
+              mention_data:
+                type: object
+                description: Mention-specific data (user_huid, name, etc.)
 
     FilePayload:
       type: object

--- a/internal/server/handler_send.go
+++ b/internal/server/handler_send.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -27,6 +28,7 @@ type SendPayload struct {
 	Status      string          `json:"status"`
 	Opts        *OptsPayload    `json:"opts,omitempty"`
 	Metadata    json.RawMessage `json:"metadata,omitempty"`
+	Mentions    json.RawMessage `json:"mentions,omitempty"`
 	RoutingMode string          `json:"routing_mode,omitempty"` // async mode: direct, catalog, mixed
 	BotID       string          `json:"bot_id,omitempty"`       // async mode: bot UUID for direct routing
 }
@@ -71,6 +73,14 @@ func (s *Server) handleSend(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if string(payload.Mentions) == "null" {
+		payload.Mentions = nil
+	}
+	if len(payload.Mentions) > 0 && payload.Mentions[0] != '[' {
+		writeError(w, http.StatusBadRequest, "mentions must be a JSON array")
 		return
 	}
 
@@ -238,6 +248,18 @@ func parseMultipart(r *http.Request, p *SendPayload) error {
 			return fmt.Errorf("invalid metadata JSON")
 		}
 		p.Metadata = raw
+	}
+
+	if mentionsStr := r.FormValue("mentions"); mentionsStr != "" {
+		raw := json.RawMessage(mentionsStr)
+		if !json.Valid(raw) {
+			return fmt.Errorf("invalid mentions JSON")
+		}
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			return fmt.Errorf("mentions must be a JSON array")
+		}
+		p.Mentions = raw
 	}
 
 	file, header, err := r.FormFile("file")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -463,6 +463,168 @@ func TestSend_Multipart_WithFile(t *testing.T) {
 	}
 }
 
+// --- send handler: mentions ---
+
+func TestSend_JSON_WithMentions(t *testing.T) {
+	var capturedPayload *SendPayload
+	cfg := Config{
+		Listen:   ":0",
+		BasePath: "/api/v1",
+		Keys:     []ResolvedKey{{Name: "t", Key: "k"}},
+	}
+	sendFn := func(ctx context.Context, p *SendPayload) (string, error) {
+		capturedPayload = p
+		return "test-sync-id", nil
+	}
+	chatResolver := func(chatID string) (ChatResolveResult, error) {
+		return ChatResolveResult{ChatID: chatID}, nil
+	}
+	srv := New(cfg, sendFn, chatResolver)
+
+	body := `{"chat_id":"chat-1","message":"@{mention:aaa-bbb} hello","mentions":[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx"}}]}`
+	w := doRequest(srv, "POST", "/api/v1/send", strings.NewReader(body), map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": "application/json",
+	})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedPayload == nil {
+		t.Fatal("send function was not called")
+	}
+	if capturedPayload.Mentions == nil {
+		t.Fatal("expected mentions to be set")
+	}
+	var mentions []json.RawMessage
+	if err := json.Unmarshal(capturedPayload.Mentions, &mentions); err != nil {
+		t.Fatalf("failed to unmarshal mentions: %v", err)
+	}
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+}
+
+func TestSend_Multipart_WithMentions(t *testing.T) {
+	var capturedPayload *SendPayload
+	cfg := Config{
+		Listen:   ":0",
+		BasePath: "/api/v1",
+		Keys:     []ResolvedKey{{Name: "t", Key: "k"}},
+	}
+	sendFn := func(ctx context.Context, p *SendPayload) (string, error) {
+		capturedPayload = p
+		return "test-sync-id", nil
+	}
+	chatResolver := func(chatID string) (ChatResolveResult, error) {
+		return ChatResolveResult{ChatID: chatID}, nil
+	}
+	srv := New(cfg, sendFn, chatResolver)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.WriteField("chat_id", "chat-1")
+	mw.WriteField("message", "@{mention:aaa-bbb} hello")
+	mw.WriteField("mentions", `[{"mention_id":"aaa-bbb","mention_type":"user","mention_data":{"user_huid":"xxx"}}]`)
+	mw.Close()
+
+	w := doRequest(srv, "POST", "/api/v1/send", &buf, map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": mw.FormDataContentType(),
+	})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedPayload == nil {
+		t.Fatal("send function was not called")
+	}
+	if capturedPayload.Mentions == nil {
+		t.Fatal("expected mentions to be set")
+	}
+	var mentions []json.RawMessage
+	if err := json.Unmarshal(capturedPayload.Mentions, &mentions); err != nil {
+		t.Fatalf("failed to unmarshal mentions: %v", err)
+	}
+	if len(mentions) != 1 {
+		t.Fatalf("expected 1 mention, got %d", len(mentions))
+	}
+}
+
+func TestSend_Multipart_MentionsInvalidJSON(t *testing.T) {
+	srv := newTestServer([]ResolvedKey{{Name: "t", Key: "k"}})
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.WriteField("chat_id", "chat-1")
+	mw.WriteField("message", "hello")
+	mw.WriteField("mentions", `not valid json`)
+	mw.Close()
+
+	w := doRequest(srv, "POST", "/api/v1/send", &buf, map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": mw.FormDataContentType(),
+	})
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseResponse(t, w)
+	if !strings.Contains(resp.Error, "invalid mentions JSON") {
+		t.Fatalf("expected 'invalid mentions JSON' error, got: %s", resp.Error)
+	}
+}
+
+func TestSend_Multipart_MentionsNotArray(t *testing.T) {
+	srv := newTestServer([]ResolvedKey{{Name: "t", Key: "k"}})
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.WriteField("chat_id", "chat-1")
+	mw.WriteField("message", "hello")
+	mw.WriteField("mentions", `{"not":"an array"}`)
+	mw.Close()
+
+	w := doRequest(srv, "POST", "/api/v1/send", &buf, map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": mw.FormDataContentType(),
+	})
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseResponse(t, w)
+	if !strings.Contains(resp.Error, "mentions must be a JSON array") {
+		t.Fatalf("expected 'mentions must be a JSON array' error, got: %s", resp.Error)
+	}
+}
+
+func TestSend_JSON_MentionsNotArray(t *testing.T) {
+	srv := newTestServer([]ResolvedKey{{Name: "t", Key: "k"}})
+
+	body := `{"chat_id":"chat-1","message":"hello","mentions":{"not":"an array"}}`
+	w := doRequest(srv, "POST", "/api/v1/send", strings.NewReader(body), map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": "application/json",
+	})
+	if w.Code != 400 {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := parseResponse(t, w)
+	if !strings.Contains(resp.Error, "mentions must be a JSON array") {
+		t.Fatalf("expected 'mentions must be a JSON array' error, got: %s", resp.Error)
+	}
+}
+
+func TestSend_JSON_MentionsNull(t *testing.T) {
+	srv := newTestServer([]ResolvedKey{{Name: "t", Key: "k"}})
+
+	body := `{"chat_id":"chat-1","message":"hello","mentions":null}`
+	w := doRequest(srv, "POST", "/api/v1/send", strings.NewReader(body), map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": "application/json",
+	})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 // --- send handler: upstream error ---
 
 func TestSend_UpstreamError(t *testing.T) {


### PR DESCRIPTION
Добавлена возможность передавать mentions (упоминания пользователей) при отправке сообщений через все каналы: CLI-команды send и enqueue, HTTP API (/api/v1/send) и асинхронную очередь.

- Новый флаг --mentions в CLI-командах send и enqueue
- Приём mentions в JSON и multipart запросах HTTP API
- Прокидывание mentions через sync/async пайплайны до BotX API
- Обновлена OpenAPI-спецификация и документация команд
- Добавлены тесты на все уровни: CLI, HTTP API, BotX-клиент