### PR TITLE
Add Alertmanager buttons and GitLab webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ curl -X POST http://localhost:8080/api/v1/send \
 ```
 
 
-Эндпоинты (все POST требуют `Authorization: Bearer <key>`):
+Эндпоинты:
 
 | Метод | Путь | Описание |
 |-------|------|----------|
@@ -93,6 +93,9 @@ curl -X POST http://localhost:8080/api/v1/send \
 | `POST` | `/api/v1/send` | Отправка сообщения |
 | `POST` | `/api/v1/alertmanager` | Вебхук Alertmanager |
 | `POST` | `/api/v1/grafana` | Вебхук Grafana |
+| `POST` | `/api/v1/gitlab` | Вебхук GitLab |
+
+`/send`, `/alertmanager` и `/grafana` требуют `Authorization: Bearer <key>` или `X-API-Key`. `/gitlab` проверяет GitLab Secret Token из заголовка `X-Gitlab-Token`.
 
 Сервер автоматически добавляет заголовок `X-Request-ID` к каждому ответу (если клиент не передал свой, генерируется уникальный). Все HTTP-запросы логируются в stderr (метод, путь, статус, время выполнения).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -294,8 +294,9 @@ express-botx serve --config config.yaml --api-key env:MY_API_KEY
 | `POST` | `{basePath}/send` | Отправка сообщения (JSON / multipart) |
 | `POST` | `{basePath}/alertmanager` | Приём вебхуков от Alertmanager |
 | `POST` | `{basePath}/grafana` | Приём вебхуков от Grafana |
+| `POST` | `{basePath}/gitlab` | Приём вебхуков от GitLab |
 
-Все `POST`-эндпоинты требуют авторизации: `Authorization: Bearer <key>` или `X-API-Key: <key>`.
+`/send`, `/alertmanager` и `/grafana` требуют авторизации: `Authorization: Bearer <key>` или `X-API-Key: <key>`. `/gitlab` проверяет GitLab Secret Token из заголовка `X-Gitlab-Token`.
 
 ### serve --enqueue (асинхронный режим)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,6 +64,18 @@ server:
   grafana:                                  # опционально — endpoint включён по умолчанию
     default_chat_id: alerts
     error_states: [alerting]              # по умолчанию
+  gitlab:                                  # опционально — endpoint включается этой секцией
+    token: env:GITLAB_WEBHOOK_TOKEN        # проверяется по X-Gitlab-Token
+    default_chat_id: deploy
+    projects:
+      group/service-a: deploy              # project path -> UUID или алиас чата
+      group/service-b: alerts
+    events:
+      push: true
+      merge_request: true
+      tag_push: true
+      pipeline: true
+      job: false
 ```
 
 ## Переменные окружения
@@ -185,6 +197,28 @@ express-botx config chat list                             # покажет (defa
 Приоритет выбора чата в HTTP-сервере:
 - `/send`: `chat_id` из запроса → чат по умолчанию → ошибка
 - `/alertmanager`, `/grafana`: `?chat_id=` → `default_chat_id` из конфига вебхука → чат по умолчанию → единственный чат → ошибка
+- `/gitlab`: `?chat_id=` → `server.gitlab.projects[project_path]` → `server.gitlab.default_chat_id` → чат по умолчанию → единственный чат → ошибка
+
+## GitLab webhooks
+
+Endpoint `POST /api/v1/gitlab` принимает встроенные webhooks GitLab. Он не использует общий `X-API-Key`; защита делается через GitLab Secret Token:
+
+```yaml
+server:
+  gitlab:
+    token: env:GITLAB_WEBHOOK_TOKEN
+    default_chat_id: deploy
+    projects:
+      group/service-a: service-a-chat
+```
+
+В GitLab настройте webhook:
+
+- URL: `https://express-botx.example.com/api/v1/gitlab`
+- Secret token: значение из `GITLAB_WEBHOOK_TOKEN`
+- Events: Push events, Merge request events, Tag push events, Pipeline events, Job events
+
+Поддержанные ключи `events`: `push`, `merge_request`, `tag_push`, `pipeline`, `job`. Если `events` не задан, принимаются все поддержанные события. Pipeline/job со статусами `failed`, `canceled`, `cancelled`, `skipped` отправляются как `status: error`.
 
 ## Формат host
 

--- a/internal/botapi/client.go
+++ b/internal/botapi/client.go
@@ -191,7 +191,33 @@ type SendNotification struct {
 	Body     string               `json:"body"`
 	Metadata json.RawMessage      `json:"metadata,omitempty"`
 	Mentions json.RawMessage      `json:"mentions,omitempty"`
+	Bubble   ButtonMarkup         `json:"bubble,omitempty"`
+	Keyboard ButtonMarkup         `json:"keyboard,omitempty"`
 	Opts     *NotificationMsgOpts `json:"opts,omitempty"`
+}
+
+// ButtonMarkup is a matrix of BotX UI buttons.
+type ButtonMarkup [][]Button
+
+// Button is a BotX bubble/keyboard button.
+type Button struct {
+	Command string          `json:"command,omitempty"`
+	Label   string          `json:"label,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Opts    *ButtonOpts     `json:"opts,omitempty"`
+}
+
+// ButtonOpts controls BotX button behavior.
+type ButtonOpts struct {
+	Silent          *bool  `json:"silent,omitempty"`
+	FontColor       string `json:"font_color,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty"`
+	Align           string `json:"align,omitempty"`
+	HSize           int    `json:"h_size,omitempty"`
+	ShowAlert       bool   `json:"show_alert,omitempty"`
+	AlertText       string `json:"alert_text,omitempty"`
+	Handler         string `json:"handler,omitempty"`
+	Link            string `json:"link,omitempty"`
 }
 
 // NotificationMsgOpts controls per-message notification behavior.
@@ -227,6 +253,8 @@ type SendParams struct {
 	File     *SendFile
 	Metadata json.RawMessage
 	Mentions json.RawMessage
+	Bubble   ButtonMarkup
+	Keyboard ButtonMarkup
 	Silent   bool
 	Stealth  bool
 	ForceDND bool
@@ -245,6 +273,8 @@ func BuildSendRequest(p *SendParams) *SendRequest {
 			Body:     p.Message,
 			Metadata: p.Metadata,
 			Mentions: p.Mentions,
+			Bubble:   p.Bubble,
+			Keyboard: p.Keyboard,
 		}
 		if p.Silent {
 			sr.Notification.Opts = &NotificationMsgOpts{
@@ -271,11 +301,13 @@ func BuildSendRequest(p *SendParams) *SendRequest {
 	}
 
 	// File-only with metadata/mentions: still need a notification to carry them
-	if sr.Notification == nil && (len(p.Metadata) > 0 || len(p.Mentions) > 0) {
+	if sr.Notification == nil && (len(p.Metadata) > 0 || len(p.Mentions) > 0 || len(p.Bubble) > 0 || len(p.Keyboard) > 0) {
 		sr.Notification = &SendNotification{
 			Status:   p.Status,
 			Metadata: p.Metadata,
 			Mentions: p.Mentions,
+			Bubble:   p.Bubble,
+			Keyboard: p.Keyboard,
 		}
 		if p.Silent {
 			sr.Notification.Opts = &NotificationMsgOpts{

--- a/internal/botapi/send_test.go
+++ b/internal/botapi/send_test.go
@@ -89,6 +89,42 @@ func TestBuildSendRequest_FileOnlyWithMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildSendRequest_Bubble(t *testing.T) {
+	silent := true
+	sr := BuildSendRequest(&SendParams{
+		ChatID:  "chat-1",
+		Status:  "ok",
+		Message: "hello",
+		Bubble: ButtonMarkup{{
+			{
+				Label: "Open alert",
+				Opts: &ButtonOpts{
+					Silent:  &silent,
+					Align:   "center",
+					Handler: "client",
+					Link:    "https://alertmanager.example.com",
+				},
+			},
+		}},
+	})
+	if sr.Notification == nil {
+		t.Fatal("expected Notification")
+	}
+	if len(sr.Notification.Bubble) != 1 || len(sr.Notification.Bubble[0]) != 1 {
+		t.Fatalf("unexpected bubble markup: %#v", sr.Notification.Bubble)
+	}
+	btn := sr.Notification.Bubble[0][0]
+	if btn.Label != "Open alert" {
+		t.Errorf("Label = %q", btn.Label)
+	}
+	if btn.Command != "" {
+		t.Errorf("Command = %q, want empty", btn.Command)
+	}
+	if btn.Opts == nil || btn.Opts.Silent == nil || !*btn.Opts.Silent || btn.Opts.Handler != "client" || btn.Opts.Link != "https://alertmanager.example.com" || btn.Opts.Align != "center" {
+		t.Errorf("Opts = %#v", btn.Opts)
+	}
+}
+
 func TestBuildSendRequest_AllOpts(t *testing.T) {
 	sr := BuildSendRequest(&SendParams{
 		ChatID:   "chat-1",

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -303,6 +303,21 @@ Options:
 	}
 	srvOpts = append(srvOpts, server.WithGrafana(grCfg))
 
+	// GitLab endpoint (enabled when configured)
+	if cfg.Server.GitLab != nil {
+		glCfg, err := buildGitLabConfig(cfg.Server.GitLab)
+		if err != nil {
+			return err
+		}
+		if glCfg.DefaultChatID == "" && len(cfg.Chats) == 1 {
+			for alias := range cfg.Chats {
+				glCfg.FallbackChatID = alias
+				vlog.V1("gitlab: using single chat alias %q as fallback", alias)
+			}
+		}
+		srvOpts = append(srvOpts, server.WithGitLab(glCfg))
+	}
+
 	// Callback endpoints
 	if cb := cfg.Server.Callbacks; cb != nil && len(cb.Rules) > 0 {
 		if err := cb.Validate(); err != nil {
@@ -513,6 +528,33 @@ func buildGrafanaConfig(gr *config.GrafanaYAMLConfig, configPath string) (*serve
 		DefaultChatID: gr.DefaultChatID,
 		ErrorStates:   states,
 		Template:      tmpl,
+	}, nil
+}
+
+func buildGitLabConfig(gl *config.GitLabYAMLConfig) (*server.GitLabConfig, error) {
+	if gl.Token == "" {
+		return nil, fmt.Errorf("gitlab: token is required")
+	}
+	token, err := secret.Resolve(gl.Token)
+	if err != nil {
+		return nil, fmt.Errorf("resolving gitlab token: %w", err)
+	}
+	if token == "" {
+		return nil, fmt.Errorf("gitlab: token is empty")
+	}
+	projects := make(map[string]string, len(gl.Projects))
+	for project, chatID := range gl.Projects {
+		projects[project] = chatID
+	}
+	events := make(map[string]bool, len(gl.Events))
+	for event, enabled := range gl.Events {
+		events[event] = enabled
+	}
+	return &server.GitLabConfig{
+		Token:         token,
+		DefaultChatID: gl.DefaultChatID,
+		Projects:      projects,
+		Events:        events,
 	}, nil
 }
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -374,6 +374,8 @@ func buildSendRequest(p *server.SendPayload) *botapi.SendRequest {
 		Status:   p.Status,
 		Metadata: p.Metadata,
 		Mentions: p.Mentions,
+		Bubble:   p.Bubble,
+		Keyboard: p.Keyboard,
 	}
 	if p.File != nil {
 		params.File = botapi.BuildFileAttachmentFromBase64(p.File.Name, p.File.Data)
@@ -420,10 +422,58 @@ func buildAlertmanagerConfig(am *config.AlertmanagerYAMLConfig, configPath strin
 		return nil, err
 	}
 
+	var button *server.AlertmanagerButtonConfig
+	var buttons []server.AlertmanagerButtonConfig
+	if am.Button != nil && am.Button.Enabled {
+		label := am.Button.Label
+		if label == "" {
+			label = "Open Alertmanager"
+		}
+		urlTemplate := am.Button.URLTemplate
+		if urlTemplate == "" {
+			urlTemplate = `{{- if .ExternalURL -}}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}{{- with index .CommonLabels "alertname" }}&alertname={{ . | urlquery }}{{- end }}{{- end -}}`
+		}
+		urlTemplate, err := secret.Resolve(urlTemplate)
+		if err != nil {
+			return nil, err
+		}
+		buttonURLTemplate, err := server.ParseAlertmanagerButtonURLTemplate(urlTemplate)
+		if err != nil {
+			return nil, err
+		}
+		button = &server.AlertmanagerButtonConfig{
+			Label:       label,
+			URLTemplate: buttonURLTemplate,
+		}
+	}
+	for _, buttonConfig := range am.Buttons {
+		if !buttonConfig.Enabled || buttonConfig.URLTemplate == "" {
+			continue
+		}
+		label := buttonConfig.Label
+		if label == "" {
+			label = "Open Alertmanager"
+		}
+		urlTemplate, err := secret.Resolve(buttonConfig.URLTemplate)
+		if err != nil {
+			return nil, err
+		}
+		buttonURLTemplate, err := server.ParseAlertmanagerButtonURLTemplate(urlTemplate)
+		if err != nil {
+			return nil, err
+		}
+		buttons = append(buttons, server.AlertmanagerButtonConfig{
+			Label:       label,
+			URLTemplate: buttonURLTemplate,
+		})
+	}
+
 	return &server.AlertmanagerConfig{
 		DefaultChatID:   am.DefaultChatID,
 		ErrorSeverities: severities,
 		Template:        tmpl,
+		Button:          button,
+		Buttons:         buttons,
 	}, nil
 }
 
@@ -841,6 +891,8 @@ func runServeEnqueue(flags config.Flags, listenFlag, apiKeyFlag string, deps Dep
 				Status:   p.Status,
 				Metadata: p.Metadata,
 				Mentions: p.Mentions,
+				Bubble:   p.Bubble,
+				Keyboard: p.Keyboard,
 			},
 			ReplyTo:    cfg.Queue.ReplyQueue,
 			EnqueuedAt: time.Now().UTC(),

--- a/internal/cmd/serve_integration_test.go
+++ b/internal/cmd/serve_integration_test.go
@@ -24,8 +24,8 @@ import (
 
 type mockBotxAPI struct {
 	mu       sync.Mutex
-	calls    []capturedSend // captured /notifications/direct calls
-	tokenVal string         // token to return
+	calls    []capturedSend                         // captured /notifications/direct calls
+	tokenVal string                                 // token to return
 	users    map[string]struct{ huid, name string } // email -> user info for lookup
 }
 
@@ -418,6 +418,35 @@ server:
 	}
 	if calls[0].GroupChatID != "d0000000-0000-0000-0000-000000000004" {
 		t.Errorf("GroupChatID = %q, want %q", calls[0].GroupChatID, "d0000000-0000-0000-0000-000000000004")
+	}
+}
+
+func TestBuildAlertmanagerConfig_ButtonURLTemplateEnv(t *testing.T) {
+	t.Setenv("TEST_ALERTMANAGER_BUTTON_URL", "https://prometheus.example.com")
+
+	amCfg, err := buildAlertmanagerConfig(&config.AlertmanagerYAMLConfig{
+		DefaultChatID: "alerts",
+		Buttons: []config.AlertmanagerButtonYAMLConfig{
+			{
+				Enabled:     true,
+				Label:       "Prometheus",
+				URLTemplate: "env:TEST_ALERTMANAGER_BUTTON_URL",
+			},
+		},
+	}, "")
+	if err != nil {
+		t.Fatalf("build alertmanager config: %v", err)
+	}
+	if len(amCfg.Buttons) != 1 {
+		t.Fatalf("Buttons len = %d, want 1", len(amCfg.Buttons))
+	}
+
+	var rendered strings.Builder
+	if err := amCfg.Buttons[0].URLTemplate.Execute(&rendered, server.AlertmanagerWebhook{}); err != nil {
+		t.Fatalf("execute button URL template: %v", err)
+	}
+	if got := rendered.String(); got != "https://prometheus.example.com" {
+		t.Fatalf("rendered URL = %q, want prometheus URL", got)
 	}
 }
 

--- a/internal/cmd/worker.go
+++ b/internal/cmd/worker.go
@@ -404,6 +404,8 @@ func buildSendRequestFromWork(msg *queue.WorkMessage) *botapi.SendRequest {
 		Status:   msg.Payload.Status,
 		Metadata: msg.Payload.Metadata,
 		Mentions: msg.Payload.Mentions,
+		Bubble:   msg.Payload.Bubble,
+		Keyboard: msg.Payload.Keyboard,
 		Silent:   msg.Payload.Opts.Silent,
 		Stealth:  msg.Payload.Opts.Stealth,
 		ForceDND: msg.Payload.Opts.ForceDND,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,10 +128,19 @@ type CallbackHandlerConfig struct {
 
 // AlertmanagerYAMLConfig holds YAML settings for the alertmanager webhook endpoint.
 type AlertmanagerYAMLConfig struct {
-	DefaultChatID   string   `yaml:"default_chat_id,omitempty"`
-	ErrorSeverities []string `yaml:"error_severities,omitempty"`
-	Template        string   `yaml:"template,omitempty"`
-	TemplateFile    string   `yaml:"template_file,omitempty"`
+	DefaultChatID   string                         `yaml:"default_chat_id,omitempty"`
+	ErrorSeverities []string                       `yaml:"error_severities,omitempty"`
+	Template        string                         `yaml:"template,omitempty"`
+	TemplateFile    string                         `yaml:"template_file,omitempty"`
+	Button          *AlertmanagerButtonYAMLConfig  `yaml:"button,omitempty"`
+	Buttons         []AlertmanagerButtonYAMLConfig `yaml:"buttons,omitempty"`
+}
+
+// AlertmanagerButtonYAMLConfig holds BotX bubble button settings for alertmanager.
+type AlertmanagerButtonYAMLConfig struct {
+	Enabled     bool   `yaml:"enabled,omitempty"`
+	Label       string `yaml:"label,omitempty"`
+	URLTemplate string `yaml:"url_template,omitempty"`
 }
 
 // GrafanaYAMLConfig holds YAML settings for the Grafana webhook endpoint.
@@ -995,7 +1004,13 @@ var knownKeys = map[string]map[string]bool{
 		"alertmanager": true, "grafana": true, "callbacks": true, "docs": true, "external_url": true,
 	},
 	"server.alertmanager": {
-		"default_chat_id": true, "error_severities": true, "template": true, "template_file": true,
+		"default_chat_id": true, "error_severities": true, "template": true, "template_file": true, "button": true, "buttons": true,
+	},
+	"server.alertmanager.button": {
+		"enabled": true, "label": true, "url_template": true,
+	},
+	"server.alertmanager.buttons.*": {
+		"enabled": true, "label": true, "url_template": true,
 	},
 	"server.grafana": {
 		"default_chat_id": true, "error_states": true, "template": true, "template_file": true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,7 @@ type ServerConfig struct {
 	AllowBotSecretAuth bool                    `yaml:"allow_bot_secret_auth,omitempty"`
 	Alertmanager       *AlertmanagerYAMLConfig `yaml:"alertmanager,omitempty"`
 	Grafana            *GrafanaYAMLConfig      `yaml:"grafana,omitempty"`
+	GitLab             *GitLabYAMLConfig       `yaml:"gitlab,omitempty"`
 	Callbacks          *CallbacksConfig        `yaml:"callbacks,omitempty"`
 	Docs               *bool                   `yaml:"docs,omitempty"`         // enable /docs endpoint (default: true)
 	ExternalURL        string                  `yaml:"external_url,omitempty"` // public URL for OpenAPI docs (e.g. http://express-botx.invitro-dev.k8s)
@@ -149,6 +150,14 @@ type GrafanaYAMLConfig struct {
 	ErrorStates   []string `yaml:"error_states,omitempty"`
 	Template      string   `yaml:"template,omitempty"`
 	TemplateFile  string   `yaml:"template_file,omitempty"`
+}
+
+// GitLabYAMLConfig holds YAML settings for the GitLab webhook endpoint.
+type GitLabYAMLConfig struct {
+	Token         string            `yaml:"token,omitempty"`           // literal, env:VAR, or vault:path#key
+	DefaultChatID string            `yaml:"default_chat_id,omitempty"` // default target chat UUID or alias
+	Projects      map[string]string `yaml:"projects,omitempty"`        // project path -> chat UUID or alias
+	Events        map[string]bool   `yaml:"events,omitempty"`          // push, merge_request, tag_push, pipeline, job
 }
 
 // APIKeyConfig defines a single API key for server authentication.
@@ -1001,7 +1010,7 @@ var knownKeys = map[string]map[string]bool{
 	},
 	"server": {
 		"listen": true, "base_path": true, "api_keys": true, "allow_bot_secret_auth": true,
-		"alertmanager": true, "grafana": true, "callbacks": true, "docs": true, "external_url": true,
+		"alertmanager": true, "grafana": true, "gitlab": true, "callbacks": true, "docs": true, "external_url": true,
 	},
 	"server.alertmanager": {
 		"default_chat_id": true, "error_severities": true, "template": true, "template_file": true, "button": true, "buttons": true,
@@ -1014,6 +1023,9 @@ var knownKeys = map[string]map[string]bool{
 	},
 	"server.grafana": {
 		"default_chat_id": true, "error_states": true, "template": true, "template_file": true,
+	},
+	"server.gitlab": {
+		"token": true, "default_chat_id": true, "projects": true, "events": true,
 	},
 	"server.callbacks": {
 		"base_path": true, "verify_jwt": true, "rules": true,
@@ -1435,6 +1447,55 @@ func (c *Config) validateCrossReferences() []ValidationResult {
 					Level:   ValidationError,
 					Path:    "server.grafana.default_chat_id",
 					Message: fmt.Sprintf("references unknown chat alias %q", chatID),
+				})
+			}
+		}
+	}
+
+	if c.Server.GitLab != nil {
+		if c.Server.GitLab.Token == "" {
+			results = append(results, ValidationResult{
+				Level:   ValidationError,
+				Path:    "server.gitlab.token",
+				Message: "gitlab webhook token is required",
+			})
+		}
+		if c.Server.GitLab.DefaultChatID != "" && !IsUUID(c.Server.GitLab.DefaultChatID) {
+			if _, ok := c.Chats[c.Server.GitLab.DefaultChatID]; !ok {
+				results = append(results, ValidationResult{
+					Level:   ValidationError,
+					Path:    "server.gitlab.default_chat_id",
+					Message: fmt.Sprintf("references unknown chat alias %q", c.Server.GitLab.DefaultChatID),
+				})
+			}
+		}
+		for project, chatID := range c.Server.GitLab.Projects {
+			if chatID == "" {
+				results = append(results, ValidationResult{
+					Level:   ValidationError,
+					Path:    fmt.Sprintf("server.gitlab.projects.%s", project),
+					Message: "chat alias or UUID is required",
+				})
+				continue
+			}
+			if !IsUUID(chatID) {
+				if _, ok := c.Chats[chatID]; !ok {
+					results = append(results, ValidationResult{
+						Level:   ValidationError,
+						Path:    fmt.Sprintf("server.gitlab.projects.%s", project),
+						Message: fmt.Sprintf("references unknown chat alias %q", chatID),
+					})
+				}
+			}
+		}
+		for event := range c.Server.GitLab.Events {
+			switch event {
+			case "push", "merge_request", "tag_push", "pipeline", "job":
+			default:
+				results = append(results, ValidationResult{
+					Level:   ValidationWarning,
+					Path:    fmt.Sprintf("server.gitlab.events.%s", event),
+					Message: "unknown GitLab event key",
 				})
 			}
 		}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/lavr/express-botx/internal/botapi"
 	"github.com/lavr/express-botx/internal/config"
 )
 
@@ -30,12 +31,14 @@ type Routing struct {
 
 // Payload carries the message content and delivery options.
 type Payload struct {
-	Message  string          `json:"message"`
-	Status   string          `json:"status,omitempty"`
-	File     *FileAttachment `json:"file,omitempty"`
-	Opts     DeliveryOpts    `json:"opts"`
-	Metadata json.RawMessage `json:"metadata,omitempty"`
-	Mentions json.RawMessage `json:"mentions,omitempty"`
+	Message  string              `json:"message"`
+	Status   string              `json:"status,omitempty"`
+	File     *FileAttachment     `json:"file,omitempty"`
+	Opts     DeliveryOpts        `json:"opts"`
+	Metadata json.RawMessage     `json:"metadata,omitempty"`
+	Mentions json.RawMessage     `json:"mentions,omitempty"`
+	Bubble   botapi.ButtonMarkup `json:"bubble,omitempty"`
+	Keyboard botapi.ButtonMarkup `json:"keyboard,omitempty"`
 }
 
 // FileAttachment is a base64-encoded file for async delivery.

--- a/internal/server/handler_alertmanager.go
+++ b/internal/server/handler_alertmanager.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/lavr/express-botx/internal/botapi"
 	vlog "github.com/lavr/express-botx/internal/log"
 )
 
@@ -16,9 +17,17 @@ type AlertmanagerConfig struct {
 	DefaultChatID   string   // default target chat UUID or alias (may be empty)
 	ErrorSeverities []string // severities that map to status "error"
 	Template        *template.Template
+	Button          *AlertmanagerButtonConfig
+	Buttons         []AlertmanagerButtonConfig
 	// FallbackChatID is resolved at startup from the config's chats section
 	// when there is exactly one chat alias configured. Empty otherwise.
 	FallbackChatID string
+}
+
+// AlertmanagerButtonConfig holds settings for a BotX bubble button under alerts.
+type AlertmanagerButtonConfig struct {
+	Label       string
+	URLTemplate *template.Template
 }
 
 // AlertmanagerWebhook is the JSON payload from Alertmanager.
@@ -111,6 +120,7 @@ func (s *Server) handleAlertmanager(w http.ResponseWriter, r *http.Request) {
 		ChatID:  chatResult.ChatID,
 		Message: message,
 		Status:  status,
+		Bubble:  s.renderAlertmanagerButtons(webhook),
 	})
 	elapsed := time.Since(start)
 
@@ -142,6 +152,63 @@ func (s *Server) resolveAlertStatus(webhook AlertmanagerWebhook) string {
 	return "ok"
 }
 
+func (s *Server) renderAlertmanagerButtons(webhook AlertmanagerWebhook) botapi.ButtonMarkup {
+	if s.amCfg == nil {
+		return nil
+	}
+
+	buttons := s.amCfg.Buttons
+	if len(buttons) == 0 && s.amCfg.Button != nil {
+		buttons = []AlertmanagerButtonConfig{*s.amCfg.Button}
+	}
+	if len(buttons) == 0 {
+		return nil
+	}
+
+	row := make([]botapi.Button, 0, len(buttons))
+	for _, button := range buttons {
+		if button.URLTemplate == nil {
+			continue
+		}
+		btn := renderAlertmanagerButton(button, webhook)
+		if btn != nil {
+			row = append(row, *btn)
+		}
+	}
+	if len(row) == 0 {
+		return nil
+	}
+	return botapi.ButtonMarkup{row}
+}
+
+func renderAlertmanagerButton(button AlertmanagerButtonConfig, webhook AlertmanagerWebhook) *botapi.Button {
+	var buf bytes.Buffer
+	if err := button.URLTemplate.Execute(&buf, webhook); err != nil {
+		vlog.V1("alertmanager: button url template error: %v", err)
+		return nil
+	}
+
+	url := buf.String()
+	if url == "" {
+		return nil
+	}
+
+	label := button.Label
+	if label == "" {
+		label = "Open Alertmanager"
+	}
+	silent := true
+	return &botapi.Button{
+		Label: label,
+		Opts: &botapi.ButtonOpts{
+			Silent:  &silent,
+			Align:   "center",
+			Handler: "client",
+			Link:    url,
+		},
+	}
+}
+
 // DefaultAlertmanagerTemplate is the built-in template for formatting alerts.
 const DefaultAlertmanagerTemplate = `{{ if eq .Status "firing" }}` + "\U0001F525" + ` FIRING{{ else }}` + "\u2705" + ` RESOLVED{{ end }} [{{ index .GroupLabels "alertname" }}]
 {{ range .Alerts }}
@@ -157,6 +224,15 @@ func ParseAlertmanagerTemplate(tmplStr string) (*template.Template, error) {
 	t, err := template.New("alertmanager").Parse(tmplStr)
 	if err != nil {
 		return nil, fmt.Errorf("parsing alertmanager template: %w", err)
+	}
+	return t, nil
+}
+
+// ParseAlertmanagerButtonURLTemplate compiles a Go text/template for alertmanager button URLs.
+func ParseAlertmanagerButtonURLTemplate(tmplStr string) (*template.Template, error) {
+	t, err := template.New("alertmanager_button_url").Parse(tmplStr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing alertmanager button url template: %w", err)
 	}
 	return t, nil
 }

--- a/internal/server/handler_gitlab.go
+++ b/internal/server/handler_gitlab.go
@@ -1,0 +1,393 @@
+package server
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/lavr/express-botx/internal/botapi"
+	vlog "github.com/lavr/express-botx/internal/log"
+)
+
+// GitLabConfig holds settings for the GitLab webhook endpoint.
+type GitLabConfig struct {
+	Token         string
+	DefaultChatID string
+	Projects      map[string]string
+	Events        map[string]bool
+	// FallbackChatID is resolved at startup from the config's chats section
+	// when there is exactly one chat alias configured. Empty otherwise.
+	FallbackChatID string
+}
+
+type gitLabProject struct {
+	Name              string `json:"name"`
+	PathWithNamespace string `json:"path_with_namespace"`
+	WebURL            string `json:"web_url"`
+}
+
+type gitLabUser struct {
+	Name     string `json:"name"`
+	Username string `json:"username"`
+}
+
+type gitLabCommit struct {
+	ID        string     `json:"id"`
+	Message   string     `json:"message"`
+	Timestamp *time.Time `json:"timestamp"`
+	URL       string     `json:"url"`
+	Author    struct {
+		Name string `json:"name"`
+	} `json:"author"`
+}
+
+type gitLabPushWebhook struct {
+	ObjectKind        string         `json:"object_kind"`
+	Ref               string         `json:"ref"`
+	Before            string         `json:"before"`
+	After             string         `json:"after"`
+	UserName          string         `json:"user_name"`
+	UserUsername      string         `json:"user_username"`
+	Project           gitLabProject  `json:"project"`
+	Commits           []gitLabCommit `json:"commits"`
+	TotalCommitsCount int            `json:"total_commits_count"`
+	CheckoutSHA       string         `json:"checkout_sha"`
+}
+
+type gitLabMergeRequestWebhook struct {
+	ObjectKind       string        `json:"object_kind"`
+	User             gitLabUser    `json:"user"`
+	Project          gitLabProject `json:"project"`
+	ObjectAttributes struct {
+		IID          int    `json:"iid"`
+		Title        string `json:"title"`
+		State        string `json:"state"`
+		Action       string `json:"action"`
+		SourceBranch string `json:"source_branch"`
+		TargetBranch string `json:"target_branch"`
+		URL          string `json:"url"`
+	} `json:"object_attributes"`
+}
+
+type gitLabPipelineWebhook struct {
+	ObjectKind       string        `json:"object_kind"`
+	User             gitLabUser    `json:"user"`
+	Project          gitLabProject `json:"project"`
+	ObjectAttributes struct {
+		ID       int    `json:"id"`
+		Ref      string `json:"ref"`
+		Status   string `json:"status"`
+		Duration int    `json:"duration"`
+		URL      string `json:"url"`
+		SHA      string `json:"sha"`
+	} `json:"object_attributes"`
+}
+
+type gitLabJobWebhook struct {
+	ObjectKind  string        `json:"object_kind"`
+	Ref         string        `json:"ref"`
+	Tag         bool          `json:"tag"`
+	BuildID     int           `json:"build_id"`
+	BuildName   string        `json:"build_name"`
+	BuildStage  string        `json:"build_stage"`
+	BuildStatus string        `json:"build_status"`
+	BuildURL    string        `json:"build_url"`
+	User        gitLabUser    `json:"user"`
+	Project     gitLabProject `json:"project"`
+}
+
+func (s *Server) handleGitLab(w http.ResponseWriter, r *http.Request) {
+	if s.glCfg == nil {
+		writeError(w, http.StatusInternalServerError, "gitlab not configured")
+		return
+	}
+	if s.glCfg.Token == "" {
+		writeError(w, http.StatusInternalServerError, "gitlab token not configured")
+		return
+	}
+	if subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Gitlab-Token")), []byte(s.glCfg.Token)) != 1 {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
+	body := json.RawMessage{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	event := normalizeGitLabEvent(r.Header.Get("X-Gitlab-Event"))
+	if event == "" {
+		writeError(w, http.StatusBadRequest, "unsupported or missing X-Gitlab-Event")
+		return
+	}
+	if !s.gitLabEventEnabled(event) {
+		vlog.V2("gitlab: event %q disabled", event)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(sendResponse{OK: true, Queued: true})
+		return
+	}
+
+	msg, err := formatGitLabMessage(event, body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	targetChat := s.resolveGitLabTargetChat(r, msg.ProjectPath)
+	if targetChat == "" {
+		writeError(w, http.StatusBadRequest, "chat_id is required: set gitlab.default_chat_id, configure a single chat alias, map the project, or pass ?chat_id=")
+		return
+	}
+	chatResult, err := s.chats(targetChat)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "resolving chat: "+err.Error())
+		return
+	}
+
+	botName, errMsg := s.resolveRequestBot(r.Context(), r.URL.Query().Get("bot"), chatResult.Bot)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
+		return
+	}
+
+	start := time.Now()
+	syncID, err := s.send(r.Context(), &SendPayload{
+		Bot:     botName,
+		ChatID:  chatResult.ChatID,
+		Message: msg.Text,
+		Status:  msg.Status,
+		Bubble:  gitLabButton(msg.URL),
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		vlog.V1("gitlab: send failed project=%s event=%s -> 502 (%dms)", msg.ProjectPath, event, elapsed.Milliseconds())
+		writeError(w, http.StatusBadGateway, "upstream error: "+err.Error())
+		return
+	}
+
+	vlog.V1("gitlab: sent project=%s event=%s to %s -> 200 (%dms)", msg.ProjectPath, event, targetChat, elapsed.Milliseconds())
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(sendResponse{OK: true, SyncID: syncID})
+}
+
+func normalizeGitLabEvent(header string) string {
+	switch strings.ToLower(strings.TrimSpace(header)) {
+	case "push hook":
+		return "push"
+	case "merge request hook":
+		return "merge_request"
+	case "tag push hook":
+		return "tag_push"
+	case "pipeline hook":
+		return "pipeline"
+	case "job hook":
+		return "job"
+	default:
+		return ""
+	}
+}
+
+func (s *Server) gitLabEventEnabled(event string) bool {
+	if len(s.glCfg.Events) == 0 {
+		return true
+	}
+	return s.glCfg.Events[event]
+}
+
+func (s *Server) resolveGitLabTargetChat(r *http.Request, projectPath string) string {
+	if q := r.URL.Query().Get("chat_id"); q != "" {
+		return q
+	}
+	if s.glCfg.Projects != nil {
+		if chatID := s.glCfg.Projects[projectPath]; chatID != "" {
+			return chatID
+		}
+	}
+	if s.glCfg.DefaultChatID != "" {
+		return s.glCfg.DefaultChatID
+	}
+	if s.cfg.DefaultChatAlias != "" {
+		return s.cfg.DefaultChatAlias
+	}
+	return s.glCfg.FallbackChatID
+}
+
+type gitLabMessage struct {
+	Text        string
+	Status      string
+	URL         string
+	ProjectPath string
+}
+
+func formatGitLabMessage(event string, body []byte) (gitLabMessage, error) {
+	switch event {
+	case "push":
+		return formatGitLabPush(body, false)
+	case "tag_push":
+		return formatGitLabPush(body, true)
+	case "merge_request":
+		return formatGitLabMergeRequest(body)
+	case "pipeline":
+		return formatGitLabPipeline(body)
+	case "job":
+		return formatGitLabJob(body)
+	default:
+		return gitLabMessage{}, fmt.Errorf("unsupported GitLab event %q", event)
+	}
+}
+
+func formatGitLabPush(body []byte, tagPush bool) (gitLabMessage, error) {
+	var p gitLabPushWebhook
+	if err := json.Unmarshal(body, &p); err != nil {
+		return gitLabMessage{}, fmt.Errorf("invalid GitLab push payload: %w", err)
+	}
+	projectPath := gitLabProjectPath(p.Project)
+	ref := gitLabRefName(p.Ref)
+	actor := firstNonEmpty(p.UserName, p.UserUsername, "unknown user")
+	status := "ok"
+	action := "pushed"
+	if isZeroGitSHA(p.After) {
+		action = "deleted"
+	}
+	if tagPush {
+		text := fmt.Sprintf("GitLab tag %s in %s: %s by %s", ref, projectPath, action, actor)
+		return gitLabMessage{Text: text, Status: status, URL: p.Project.WebURL, ProjectPath: projectPath}, nil
+	}
+
+	count := p.TotalCommitsCount
+	if count == 0 {
+		count = len(p.Commits)
+	}
+	text := fmt.Sprintf("GitLab push to %s/%s: %d commit(s) %s by %s", projectPath, ref, count, action, actor)
+	if len(p.Commits) > 0 {
+		text += "\n" + gitLabCommitSummary(p.Commits)
+	}
+	url := p.Project.WebURL
+	if p.After != "" && !isZeroGitSHA(p.After) {
+		url = p.Project.WebURL + "/-/commit/" + p.After
+	}
+	return gitLabMessage{Text: text, Status: status, URL: url, ProjectPath: projectPath}, nil
+}
+
+func formatGitLabMergeRequest(body []byte) (gitLabMessage, error) {
+	var mr gitLabMergeRequestWebhook
+	if err := json.Unmarshal(body, &mr); err != nil {
+		return gitLabMessage{}, fmt.Errorf("invalid GitLab merge request payload: %w", err)
+	}
+	projectPath := gitLabProjectPath(mr.Project)
+	a := mr.ObjectAttributes
+	actor := firstNonEmpty(mr.User.Name, mr.User.Username, "unknown user")
+	action := firstNonEmpty(a.Action, a.State, "updated")
+	text := fmt.Sprintf("GitLab MR !%d %s in %s: %s\n%s -> %s by %s", a.IID, action, projectPath, a.Title, a.SourceBranch, a.TargetBranch, actor)
+	return gitLabMessage{Text: text, Status: "ok", URL: a.URL, ProjectPath: projectPath}, nil
+}
+
+func formatGitLabPipeline(body []byte) (gitLabMessage, error) {
+	var p gitLabPipelineWebhook
+	if err := json.Unmarshal(body, &p); err != nil {
+		return gitLabMessage{}, fmt.Errorf("invalid GitLab pipeline payload: %w", err)
+	}
+	projectPath := gitLabProjectPath(p.Project)
+	a := p.ObjectAttributes
+	actor := firstNonEmpty(p.User.Name, p.User.Username, "unknown user")
+	text := fmt.Sprintf("GitLab pipeline #%d %s in %s/%s by %s", a.ID, a.Status, projectPath, a.Ref, actor)
+	if a.Duration > 0 {
+		text += fmt.Sprintf(" (%s)", (time.Duration(a.Duration) * time.Second).String())
+	}
+	return gitLabMessage{Text: text, Status: gitLabStatus(a.Status), URL: a.URL, ProjectPath: projectPath}, nil
+}
+
+func formatGitLabJob(body []byte) (gitLabMessage, error) {
+	var j gitLabJobWebhook
+	if err := json.Unmarshal(body, &j); err != nil {
+		return gitLabMessage{}, fmt.Errorf("invalid GitLab job payload: %w", err)
+	}
+	projectPath := gitLabProjectPath(j.Project)
+	actor := firstNonEmpty(j.User.Name, j.User.Username, "unknown user")
+	text := fmt.Sprintf("GitLab job %s/%s #%d %s in %s/%s by %s", j.BuildStage, j.BuildName, j.BuildID, j.BuildStatus, projectPath, j.Ref, actor)
+	return gitLabMessage{Text: text, Status: gitLabStatus(j.BuildStatus), URL: j.BuildURL, ProjectPath: projectPath}, nil
+}
+
+func gitLabProjectPath(project gitLabProject) string {
+	return firstNonEmpty(project.PathWithNamespace, project.Name, "unknown/project")
+}
+
+func gitLabRefName(ref string) string {
+	if ref == "" {
+		return "unknown"
+	}
+	return path.Base(ref)
+}
+
+func gitLabCommitSummary(commits []gitLabCommit) string {
+	limit := len(commits)
+	if limit > 3 {
+		limit = 3
+	}
+	lines := make([]string, 0, limit+1)
+	for i := 0; i < limit; i++ {
+		sha := commits[i].ID
+		if len(sha) > 8 {
+			sha = sha[:8]
+		}
+		message := strings.TrimSpace(strings.SplitN(commits[i].Message, "\n", 2)[0])
+		author := commits[i].Author.Name
+		if author != "" {
+			lines = append(lines, fmt.Sprintf("- %s %s (%s)", sha, message, author))
+		} else {
+			lines = append(lines, fmt.Sprintf("- %s %s", sha, message))
+		}
+	}
+	if len(commits) > limit {
+		lines = append(lines, fmt.Sprintf("- ... and %d more", len(commits)-limit))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func gitLabStatus(status string) string {
+	switch strings.ToLower(status) {
+	case "failed", "canceled", "cancelled", "skipped":
+		return "error"
+	default:
+		return "ok"
+	}
+}
+
+func gitLabButton(url string) botapi.ButtonMarkup {
+	if url == "" {
+		return nil
+	}
+	silent := true
+	return botapi.ButtonMarkup{{
+		{
+			Label: "Open GitLab",
+			Opts: &botapi.ButtonOpts{
+				Silent:  &silent,
+				Align:   "center",
+				Handler: "client",
+				Link:    url,
+			},
+		},
+	}}
+}
+
+func isZeroGitSHA(s string) bool {
+	return s != "" && strings.Trim(s, "0") == ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/server/handler_gitlab_test.go
+++ b/internal/server/handler_gitlab_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func newGitLabTestServer(t *testing.T, glCfg *GitLabConfig) (*Server, *[]SendPayload) {
+	t.Helper()
+	sent := []SendPayload{}
+	cfg := Config{
+		Listen:   ":0",
+		BasePath: "/api/v1",
+	}
+	sendFn := func(ctx context.Context, p *SendPayload) (string, error) {
+		sent = append(sent, *p)
+		return "gitlab-sync-id", nil
+	}
+	chatResolver := func(chatID string) (ChatResolveResult, error) {
+		return ChatResolveResult{ChatID: "resolved-" + chatID}, nil
+	}
+	return New(cfg, sendFn, chatResolver, WithGitLab(glCfg)), &sent
+}
+
+func gitLabHeaders(event, token string) map[string]string {
+	return map[string]string{
+		"Content-Type":   "application/json",
+		"X-Gitlab-Event": event,
+		"X-Gitlab-Token": token,
+	}
+}
+
+func TestGitLab_PushProjectRouting(t *testing.T) {
+	srv, sent := newGitLabTestServer(t, &GitLabConfig{
+		Token: "secret",
+		Projects: map[string]string{
+			"group/service": "service-chat",
+		},
+	})
+
+	body := `{
+		"object_kind": "push",
+		"ref": "refs/heads/main",
+		"after": "1234567890abcdef",
+		"user_name": "Ivan",
+		"project": {
+			"name": "service",
+			"path_with_namespace": "group/service",
+			"web_url": "https://gitlab.example.com/group/service"
+		},
+		"total_commits_count": 2,
+		"commits": [
+			{"id":"1234567890abcdef","message":"first commit\nbody","author":{"name":"Ivan"}},
+			{"id":"abcdef1234567890","message":"second commit","author":{"name":"Petr"}}
+		]
+	}`
+
+	w := doRequest(srv, "POST", "/api/v1/gitlab", strings.NewReader(body), gitLabHeaders("Push Hook", "secret"))
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("expected 1 sent payload, got %d", len(*sent))
+	}
+	got := (*sent)[0]
+	if got.ChatID != "resolved-service-chat" {
+		t.Fatalf("ChatID = %q, want resolved-service-chat", got.ChatID)
+	}
+	if got.Status != "ok" {
+		t.Fatalf("Status = %q, want ok", got.Status)
+	}
+	if !strings.Contains(got.Message, "GitLab push to group/service/main") {
+		t.Fatalf("unexpected message: %s", got.Message)
+	}
+	if len(got.Bubble) != 1 || len(got.Bubble[0]) != 1 {
+		t.Fatalf("expected GitLab button, got %#v", got.Bubble)
+	}
+}
+
+func TestGitLab_InvalidToken(t *testing.T) {
+	srv, sent := newGitLabTestServer(t, &GitLabConfig{
+		Token:         "secret",
+		DefaultChatID: "gitlab-chat",
+	})
+
+	w := doRequest(srv, "POST", "/api/v1/gitlab", strings.NewReader(`{}`), gitLabHeaders("Push Hook", "wrong"))
+	if w.Code != 403 {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(*sent) != 0 {
+		t.Fatalf("expected no sent payloads, got %d", len(*sent))
+	}
+}
+
+func TestGitLab_PipelineFailedStatus(t *testing.T) {
+	srv, sent := newGitLabTestServer(t, &GitLabConfig{
+		Token:         "secret",
+		DefaultChatID: "gitlab-chat",
+	})
+
+	body := `{
+		"object_kind": "pipeline",
+		"user": {"name": "Ivan"},
+		"project": {
+			"name": "service",
+			"path_with_namespace": "group/service",
+			"web_url": "https://gitlab.example.com/group/service"
+		},
+		"object_attributes": {
+			"id": 42,
+			"ref": "main",
+			"status": "failed",
+			"duration": 61,
+			"url": "https://gitlab.example.com/group/service/-/pipelines/42"
+		}
+	}`
+
+	w := doRequest(srv, "POST", "/api/v1/gitlab", strings.NewReader(body), gitLabHeaders("Pipeline Hook", "secret"))
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("expected 1 sent payload, got %d", len(*sent))
+	}
+	got := (*sent)[0]
+	if got.Status != "error" {
+		t.Fatalf("Status = %q, want error", got.Status)
+	}
+	if !strings.Contains(got.Message, "pipeline #42 failed") {
+		t.Fatalf("unexpected message: %s", got.Message)
+	}
+}
+
+func TestGitLab_DisabledEventAcceptedWithoutSend(t *testing.T) {
+	srv, sent := newGitLabTestServer(t, &GitLabConfig{
+		Token:         "secret",
+		DefaultChatID: "gitlab-chat",
+		Events: map[string]bool{
+			"push":          true,
+			"merge_request": false,
+			"pipeline":      false,
+			"tag_push":      false,
+			"job":           false,
+		},
+	})
+
+	body := `{
+		"object_kind": "pipeline",
+		"project": {"path_with_namespace": "group/service"},
+		"object_attributes": {"id": 42, "ref": "main", "status": "success"}
+	}`
+
+	w := doRequest(srv, "POST", "/api/v1/gitlab", strings.NewReader(body), gitLabHeaders("Pipeline Hook", "secret"))
+	if w.Code != 202 {
+		t.Fatalf("expected 202, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(*sent) != 0 {
+		t.Fatalf("expected no sent payloads, got %d", len(*sent))
+	}
+}

--- a/internal/server/handler_send.go
+++ b/internal/server/handler_send.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/lavr/express-botx/internal/botapi"
 	vlog "github.com/lavr/express-botx/internal/log"
 	"github.com/lavr/express-botx/internal/mentions"
 )
@@ -22,17 +23,19 @@ func isUUID(s string) bool { return uuidRe.MatchString(s) }
 
 // SendPayload is the parsed request for sending a message.
 type SendPayload struct {
-	Bot         string          `json:"bot,omitempty"`
-	ChatID      string          `json:"chat_id"`
-	Message     string          `json:"message"`
-	File        *FilePayload    `json:"file,omitempty"`
-	Status      string          `json:"status"`
-	Opts        *OptsPayload    `json:"opts,omitempty"`
-	Metadata    json.RawMessage `json:"metadata,omitempty"`
-	Mentions    json.RawMessage `json:"mentions,omitempty"`
-	RoutingMode string          `json:"routing_mode,omitempty"` // async mode: direct, catalog, mixed
-	BotID       string          `json:"bot_id,omitempty"`       // async mode: bot UUID for direct routing
-	NoParse     bool            `json:"-"`                      // internal: skip mentions parsing (set by handler for async mode)
+	Bot         string              `json:"bot,omitempty"`
+	ChatID      string              `json:"chat_id"`
+	Message     string              `json:"message"`
+	File        *FilePayload        `json:"file,omitempty"`
+	Status      string              `json:"status"`
+	Opts        *OptsPayload        `json:"opts,omitempty"`
+	Metadata    json.RawMessage     `json:"metadata,omitempty"`
+	Mentions    json.RawMessage     `json:"mentions,omitempty"`
+	Bubble      botapi.ButtonMarkup `json:"bubble,omitempty"`
+	Keyboard    botapi.ButtonMarkup `json:"keyboard,omitempty"`
+	RoutingMode string              `json:"routing_mode,omitempty"` // async mode: direct, catalog, mixed
+	BotID       string              `json:"bot_id,omitempty"`       // async mode: bot UUID for direct routing
+	NoParse     bool                `json:"-"`                      // internal: skip mentions parsing (set by handler for async mode)
 }
 
 // FilePayload represents a file attachment in the JSON request.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	chatEntries          []config.ChatEntry // for GET /chats/alias/list
 	amCfg                *AlertmanagerConfig
 	grCfg                *GrafanaConfig
+	glCfg                *GitLabConfig
 	mentionsResolver     mentions.UserResolver
 	botMentionsResolvers map[string]mentions.UserResolver // per-bot resolvers for multi-host setups
 	callbackRouter       *CallbackRouter
@@ -93,6 +94,13 @@ func WithAlertmanager(cfg *AlertmanagerConfig) Option {
 func WithGrafana(cfg *GrafanaConfig) Option {
 	return func(s *Server) {
 		s.grCfg = cfg
+	}
+}
+
+// WithGitLab enables the GitLab webhook endpoint.
+func WithGitLab(cfg *GitLabConfig) Option {
+	return func(s *Server) {
+		s.glCfg = cfg
 	}
 }
 
@@ -279,6 +287,20 @@ func New(cfg Config, sendFn SendFunc, chatResolver ChatResolver, opts ...Option)
 			chatInfo = s.grCfg.FallbackChatID
 		}
 		vlog.Info("server: grafana endpoint enabled (chat: %s)", chatInfo)
+	}
+
+	if s.glCfg != nil {
+		full := base + "/gitlab"
+		r.Method("POST", full, s.apm.WrapHandler("POST /gitlab", http.HandlerFunc(s.handleGitLab)))
+		chatInfo := "from ?chat_id param"
+		if s.glCfg.DefaultChatID != "" {
+			chatInfo = s.glCfg.DefaultChatID
+		} else if cfg.DefaultChatAlias != "" {
+			chatInfo = cfg.DefaultChatAlias
+		} else if s.glCfg.FallbackChatID != "" {
+			chatInfo = s.glCfg.FallbackChatID
+		}
+		vlog.Info("server: gitlab endpoint enabled (chat: %s, projects: %d)", chatInfo, len(s.glCfg.Projects))
 	}
 
 	if s.callbackRouter != nil && s.callbacksCfg != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -905,6 +905,160 @@ func TestAlertmanager_ChatIDQueryParam(t *testing.T) {
 	}
 }
 
+func TestAlertmanager_Button(t *testing.T) {
+	tmpl, _ := ParseAlertmanagerTemplate(`test`)
+	buttonURLTemplate, err := ParseAlertmanagerButtonURLTemplate(`{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}&alertname={{ index .CommonLabels "alertname" | urlquery }}`)
+	if err != nil {
+		t.Fatalf("parse button template: %v", err)
+	}
+	amCfg := &AlertmanagerConfig{
+		DefaultChatID:   "default-chat",
+		ErrorSeverities: []string{"critical"},
+		Template:        tmpl,
+		Button: &AlertmanagerButtonConfig{
+			Label:       "Open alert",
+			URLTemplate: buttonURLTemplate,
+		},
+	}
+
+	var captured *SendPayload
+	cfg := Config{
+		Listen:   ":0",
+		BasePath: "/api/v1",
+		Keys:     []ResolvedKey{{Name: "t", Key: "k"}},
+	}
+	sendFn := func(ctx context.Context, p *SendPayload) (string, error) {
+		captured = p
+		return "id", nil
+	}
+	chatResolver := func(chatID string) (ChatResolveResult, error) { return ChatResolveResult{ChatID: chatID}, nil }
+	srv := New(cfg, sendFn, chatResolver, WithAlertmanager(amCfg))
+
+	webhook := AlertmanagerWebhook{
+		Version:      "4",
+		Status:       "firing",
+		Receiver:     "team-express",
+		GroupLabels:  map[string]string{"alertname": "TestAlert"},
+		CommonLabels: map[string]string{"alertname": "TestAlert"},
+		ExternalURL:  "https://alertmanager.example.com",
+		Alerts: []AlertItem{{
+			Status: "firing",
+			Labels: map[string]string{"alertname": "TestAlert", "severity": "critical"},
+		}},
+	}
+	body, _ := json.Marshal(webhook)
+
+	w := doRequest(srv, "POST", "/api/v1/alertmanager", bytes.NewReader(body), map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": "application/json",
+	})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("expected captured payload")
+	}
+	if len(captured.Bubble) != 1 || len(captured.Bubble[0]) != 1 {
+		t.Fatalf("unexpected bubble markup: %#v", captured.Bubble)
+	}
+	btn := captured.Bubble[0][0]
+	if btn.Label != "Open alert" {
+		t.Errorf("Label = %q", btn.Label)
+	}
+	wantURL := "https://alertmanager.example.com/#/alerts?receiver=team-express&alertname=TestAlert"
+	if btn.Command != "" {
+		t.Errorf("Command = %q, want empty", btn.Command)
+	}
+	if btn.Opts == nil || btn.Opts.Handler != "client" || btn.Opts.Silent == nil || !*btn.Opts.Silent || btn.Opts.Link != wantURL || btn.Opts.Align != "center" {
+		t.Errorf("Opts = %#v", btn.Opts)
+	}
+}
+
+func TestAlertmanager_Buttons(t *testing.T) {
+	tmpl, _ := ParseAlertmanagerTemplate(`test`)
+	alertmanagerURLTemplate, err := ParseAlertmanagerButtonURLTemplate(`{{ .ExternalURL }}`)
+	if err != nil {
+		t.Fatalf("parse alertmanager button template: %v", err)
+	}
+	prometheusURLTemplate, err := ParseAlertmanagerButtonURLTemplate(`https://prometheus.example.com`)
+	if err != nil {
+		t.Fatalf("parse prometheus button template: %v", err)
+	}
+	grafanaURLTemplate, err := ParseAlertmanagerButtonURLTemplate(`https://grafana.example.com`)
+	if err != nil {
+		t.Fatalf("parse grafana button template: %v", err)
+	}
+	amCfg := &AlertmanagerConfig{
+		DefaultChatID:   "default-chat",
+		ErrorSeverities: []string{"critical"},
+		Template:        tmpl,
+		Buttons: []AlertmanagerButtonConfig{
+			{Label: "Alertmanager", URLTemplate: alertmanagerURLTemplate},
+			{Label: "Prometheus", URLTemplate: prometheusURLTemplate},
+			{Label: "Grafana", URLTemplate: grafanaURLTemplate},
+		},
+	}
+
+	var captured *SendPayload
+	cfg := Config{
+		Listen:   ":0",
+		BasePath: "/api/v1",
+		Keys:     []ResolvedKey{{Name: "t", Key: "k"}},
+	}
+	sendFn := func(ctx context.Context, p *SendPayload) (string, error) {
+		captured = p
+		return "id", nil
+	}
+	chatResolver := func(chatID string) (ChatResolveResult, error) { return ChatResolveResult{ChatID: chatID}, nil }
+	srv := New(cfg, sendFn, chatResolver, WithAlertmanager(amCfg))
+
+	webhook := AlertmanagerWebhook{
+		Version:     "4",
+		Status:      "firing",
+		Receiver:    "team-express",
+		ExternalURL: "https://alertmanager.example.com",
+		Alerts: []AlertItem{{
+			Status: "firing",
+			Labels: map[string]string{"severity": "critical"},
+		}},
+	}
+	body, _ := json.Marshal(webhook)
+
+	w := doRequest(srv, "POST", "/api/v1/alertmanager", bytes.NewReader(body), map[string]string{
+		"X-API-Key":    "k",
+		"Content-Type": "application/json",
+	})
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured == nil {
+		t.Fatal("expected captured payload")
+	}
+	if len(captured.Bubble) != 1 || len(captured.Bubble[0]) != 3 {
+		t.Fatalf("unexpected bubble markup: %#v", captured.Bubble)
+	}
+	want := []struct {
+		label string
+		link  string
+	}{
+		{"Alertmanager", "https://alertmanager.example.com"},
+		{"Prometheus", "https://prometheus.example.com"},
+		{"Grafana", "https://grafana.example.com"},
+	}
+	for i, wantButton := range want {
+		btn := captured.Bubble[0][i]
+		if btn.Label != wantButton.label {
+			t.Errorf("button %d Label = %q, want %q", i, btn.Label, wantButton.label)
+		}
+		if btn.Command != "" {
+			t.Errorf("button %d Command = %q, want empty", i, btn.Command)
+		}
+		if btn.Opts == nil || btn.Opts.Handler != "client" || btn.Opts.Silent == nil || !*btn.Opts.Silent || btn.Opts.Link != wantButton.link || btn.Opts.Align != "center" {
+			t.Errorf("button %d Opts = %#v", i, btn.Opts)
+		}
+	}
+}
+
 func TestAlertmanager_NoChatID(t *testing.T) {
 	tmpl, _ := ParseAlertmanagerTemplate(`test`)
 	amCfg := &AlertmanagerConfig{


### PR DESCRIPTION
## Summary
- add BotX bubble/keyboard button support to send payloads and Alertmanager webhooks
- add GitLab webhook endpoint with Secret Token validation, event filtering, project-to-chat routing, and GitLab open button
- document GitLab webhook configuration and endpoint auth behavior

## Tests
- go test ./...